### PR TITLE
ActivityPub: add avatar handling, unify comment target resolution, disable replies to federated comments, and persist Fediverse instance in UI

### DIFF
--- a/server/internal/app/activitypub/service.go
+++ b/server/internal/app/activitypub/service.go
@@ -187,10 +187,12 @@ func (s *stringList) UnmarshalJSON(raw []byte) error {
 }
 
 type remoteActor struct {
-	ID                string `json:"id"`
-	PreferredUsername string `json:"preferredUsername"`
-	Name              string `json:"name"`
-	Inbox             string `json:"inbox"`
+	ID                string          `json:"id"`
+	PreferredUsername string          `json:"preferredUsername"`
+	Name              string          `json:"name"`
+	Icon              *remoteMediaRef `json:"icon"`
+	Image             *remoteMediaRef `json:"image"`
+	Inbox             string          `json:"inbox"`
 	Endpoints         struct {
 		SharedInbox string `json:"sharedInbox"`
 	} `json:"endpoints"`
@@ -198,6 +200,15 @@ type remoteActor struct {
 		ID           string `json:"id"`
 		PublicKeyPEM string `json:"publicKeyPem"`
 	} `json:"publicKey"`
+}
+
+type remoteMediaRef struct {
+	Type string `json:"type"`
+	URL  string `json:"url"`
+}
+
+type commentTarget struct {
+	AreaID int64
 }
 
 func NewService(
@@ -842,18 +853,23 @@ func (s *Service) handleCreateAsComment(ctx context.Context, baseURL string, act
 		}
 	}
 
-	article, parent, err := s.resolveCommentTarget(ctx, baseURL, inReplyTo)
-	if err != nil || article == nil || article.CommentID == nil {
+	target, parent, err := s.resolveCommentTarget(ctx, baseURL, inReplyTo)
+	if err != nil || target == nil {
 		return nil
 	}
 
 	nick := extractDisplayNameFromActor(actorID)
+	avatar := ""
 	if remote, err := s.fetchRemoteActor(ctx, actorID); err == nil && remote != nil {
 		if strings.TrimSpace(remote.PreferredUsername) != "" {
 			nick = strings.TrimSpace(remote.PreferredUsername)
 		}
 		if strings.TrimSpace(remote.Name) != "" && nick == "" {
 			nick = strings.TrimSpace(remote.Name)
+		}
+		avatarURL := remote.avatarURL()
+		if avatarURL != "" {
+			avatar = avatarURL
 		}
 	}
 	if nick == "" {
@@ -865,13 +881,14 @@ func (s *Service) handleCreateAsComment(ctx context.Context, baseURL string, act
 	}
 
 	entity := &domaincomment.Comment{
-		AreaID:            *article.CommentID,
+		AreaID:            target.AreaID,
 		Content:           contentText,
 		AuthorID:          nil,
 		VisitorID:         strPtr(actorID),
 		NickName:          strPtr(nick),
 		Email:             nil,
 		Website:           strPtr(strings.TrimSpace(actorID)),
+		Avatar:            strPtr(strings.TrimSpace(avatar)),
 		IsOwner:           false,
 		IsFriend:          false,
 		IsAuthor:          false,
@@ -891,29 +908,40 @@ func (s *Service) handleCreateAsComment(ctx context.Context, baseURL string, act
 	return s.commentRepo.Create(ctx, entity)
 }
 
-func (s *Service) resolveCommentTarget(ctx context.Context, baseURL string, inReplyTo string) (*content.Article, *domaincomment.Comment, error) {
+func (s *Service) resolveCommentTarget(ctx context.Context, baseURL string, inReplyTo string) (*commentTarget, *domaincomment.Comment, error) {
 	if s.commentRepo != nil {
 		if parent, err := s.commentRepo.FindByFederatedObjectID(ctx, inReplyTo); err == nil && parent != nil {
 			area, err := s.commentRepo.GetAreaByID(ctx, parent.AreaID)
-			if err != nil || area == nil || area.Type != "article" || area.ContentID == nil {
+			if err != nil || area == nil {
 				return nil, nil, err
 			}
-			article, err := s.contentRepo.GetArticleByID(ctx, *area.ContentID)
-			return article, parent, err
+			return &commentTarget{AreaID: area.ID}, parent, nil
 		}
 	}
 
 	if article, err := s.contentRepo.GetArticleByActivityPubObjectID(ctx, inReplyTo); err == nil {
-		return article, nil, nil
+		if article != nil && article.CommentID != nil {
+			return &commentTarget{AreaID: *article.CommentID}, nil, nil
+		}
+	}
+	if moment, err := s.contentRepo.GetMomentByActivityPubObjectID(ctx, inReplyTo); err == nil {
+		if moment != nil && moment.CommentID != nil {
+			return &commentTarget{AreaID: *moment.CommentID}, nil, nil
+		}
+	}
+	if s.thinkingRepo != nil {
+		if item, err := s.thinkingRepo.FindByActivityPubObjectID(ctx, inReplyTo); err == nil && item != nil {
+			return &commentTarget{AreaID: item.CommentID}, nil, nil
+		}
 	}
 
-	if article := s.resolveArticleByLocalURL(ctx, baseURL, inReplyTo); article != nil {
-		return article, nil, nil
+	if target := s.resolveContentByLocalURL(ctx, baseURL, inReplyTo); target != nil {
+		return target, nil, nil
 	}
 	return nil, nil, nil
 }
 
-func (s *Service) resolveArticleByLocalURL(ctx context.Context, baseURL, raw string) *content.Article {
+func (s *Service) resolveContentByLocalURL(ctx context.Context, baseURL, raw string) *commentTarget {
 	u, err := url.Parse(strings.TrimSpace(raw))
 	if err != nil {
 		return nil
@@ -936,7 +964,44 @@ func (s *Service) resolveArticleByLocalURL(ctx context.Context, baseURL, raw str
 		if err != nil {
 			return nil
 		}
-		return item
+		if item.CommentID == nil {
+			return nil
+		}
+		return &commentTarget{AreaID: *item.CommentID}
+	}
+	if strings.HasPrefix(path, "/moments/") {
+		slug := strings.TrimPrefix(path, "/moments/")
+		parts := strings.Split(strings.Trim(slug, "/"), "/")
+		if len(parts) == 0 {
+			return nil
+		}
+		shortURL := strings.TrimSpace(parts[len(parts)-1])
+		if shortURL == "" {
+			return nil
+		}
+		item, err := s.contentRepo.GetMomentByShortURL(ctx, shortURL)
+		if err != nil || item == nil || item.CommentID == nil {
+			return nil
+		}
+		return &commentTarget{AreaID: *item.CommentID}
+	}
+	if strings.HasPrefix(path, "/thinkings") {
+		fragment := strings.TrimSpace(u.Fragment)
+		if strings.HasPrefix(fragment, "thinking-") {
+			rawID := strings.TrimPrefix(fragment, "thinking-")
+			id, err := strconv.ParseInt(rawID, 10, 64)
+			if err != nil {
+				return nil
+			}
+			if s.thinkingRepo == nil {
+				return nil
+			}
+			item, err := s.thinkingRepo.FindByID(ctx, id)
+			if err != nil || item == nil {
+				return nil
+			}
+			return &commentTarget{AreaID: item.CommentID}
+		}
 	}
 	if strings.HasPrefix(path, "/ap/objects/article-") {
 		rawID := strings.TrimPrefix(path, "/ap/objects/article-")
@@ -948,9 +1013,53 @@ func (s *Service) resolveArticleByLocalURL(ctx context.Context, baseURL, raw str
 		if err != nil {
 			return nil
 		}
-		return item
+		if item.CommentID == nil {
+			return nil
+		}
+		return &commentTarget{AreaID: *item.CommentID}
+	}
+	if strings.HasPrefix(path, "/ap/objects/moment-") {
+		rawID := strings.TrimPrefix(path, "/ap/objects/moment-")
+		id, err := strconv.ParseInt(rawID, 10, 64)
+		if err != nil {
+			return nil
+		}
+		item, err := s.contentRepo.GetMomentByID(ctx, id)
+		if err != nil || item == nil || item.CommentID == nil {
+			return nil
+		}
+		return &commentTarget{AreaID: *item.CommentID}
+	}
+	if strings.HasPrefix(path, "/ap/objects/thinking-") {
+		rawID := strings.TrimPrefix(path, "/ap/objects/thinking-")
+		id, err := strconv.ParseInt(rawID, 10, 64)
+		if err != nil || s.thinkingRepo == nil {
+			return nil
+		}
+		item, err := s.thinkingRepo.FindByID(ctx, id)
+		if err != nil || item == nil {
+			return nil
+		}
+		return &commentTarget{AreaID: item.CommentID}
 	}
 	return nil
+}
+
+func (a *remoteActor) avatarURL() string {
+	if a == nil {
+		return ""
+	}
+	if a.Icon != nil {
+		if url := strings.TrimSpace(a.Icon.URL); url != "" {
+			return url
+		}
+	}
+	if a.Image != nil {
+		if url := strings.TrimSpace(a.Image.URL); url != "" {
+			return url
+		}
+	}
+	return ""
 }
 
 func (s *Service) notifyAdminsMention(ctx context.Context, actorID string, note noteObject) error {

--- a/server/internal/app/comment/service.go
+++ b/server/internal/app/comment/service.go
@@ -451,6 +451,9 @@ func (s *Service) ReplyComment(ctx context.Context, cmd ReplyCommentCmd) (*domai
 	if err != nil {
 		return nil, err
 	}
+	if parent.IsFederated {
+		return nil, domaincomment.ErrCommentReplyDisabled
+	}
 	if err := s.ensureParentValid(ctx, parent.AreaID, parent.ID); err != nil {
 		return nil, err
 	}

--- a/web/src/lib/features/comment/components/CommentAreaClient.svelte
+++ b/web/src/lib/features/comment/components/CommentAreaClient.svelte
@@ -46,13 +46,7 @@
 	const query = createQuery(() => ({
 		queryKey: ['comments', areaId, currentPage, viewerKey],
 		queryFn: () =>
-			getCommentTree(
-				undefined,
-				areaId,
-				currentPage,
-				pageSize,
-				viewerVisitorId || undefined
-			)
+			getCommentTree(undefined, areaId, currentPage, pageSize, viewerVisitorId || undefined)
 	}));
 
 	commentAreaCtx.mountModelData(() => createInitialModel());
@@ -85,8 +79,10 @@
 	const totalPages = $derived(Math.ceil(($commentAreaModel?.total ?? 0) / pageSize));
 	const normalizedObjectUrl = $derived((fediverseObjectUrl ?? '').trim());
 	const showFediverseSection = $derived(normalizedObjectUrl.length > 0);
+	const fediverseInstanceDomainStorageKey = 'comment:fediverse-instance-domain';
 	let copied = $state(false);
 	let instanceDomain = $state('');
+	let instanceDomainHydrated = $state(false);
 
 	const handlePageChange = (page: number) => {
 		if (page < 1 || page > totalPages) return;
@@ -110,7 +106,10 @@
 
 	const openOnInstance = () => {
 		if (!browser || !normalizedObjectUrl) return;
-		const domain = instanceDomain.trim().replace(/^https?:\/\//, '').replace(/\/+$/, '');
+		const domain = instanceDomain
+			.trim()
+			.replace(/^https?:\/\//, '')
+			.replace(/\/+$/, '');
 		if (!domain) return;
 		window.open(
 			`https://${domain}/authorize_interaction?uri=${encodeURIComponent(normalizedObjectUrl)}`,
@@ -118,6 +117,25 @@
 			'noopener,noreferrer'
 		);
 	};
+
+	$effect(() => {
+		if (!browser || instanceDomainHydrated) return;
+		const stored = localStorage.getItem(fediverseInstanceDomainStorageKey);
+		if (stored) {
+			instanceDomain = stored.trim();
+		}
+		instanceDomainHydrated = true;
+	});
+
+	$effect(() => {
+		if (!browser || !instanceDomainHydrated) return;
+		const trimmedDomain = instanceDomain.trim();
+		if (!trimmedDomain) {
+			localStorage.removeItem(fediverseInstanceDomainStorageKey);
+			return;
+		}
+		localStorage.setItem(fediverseInstanceDomainStorageKey, trimmedDomain);
+	});
 </script>
 
 <div class="mt-16 pt-10 border-t border-ink-100 dark:border-ink-800/50" id="comments">
@@ -163,39 +181,8 @@
 		</div>
 	</div>
 
-	<CommentList />
-
-	{#if totalPages > 1}
-		<div class="flex items-center justify-center gap-2 mt-8 mb-12">
-			<button
-				class="p-2 rounded-lg text-ink-500 hover:bg-ink-100 dark:text-ink-400 dark:hover:bg-ink-800 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-				disabled={currentPage === 1}
-				onclick={() => handlePageChange(currentPage - 1)}
-				aria-label="上一页"
-			>
-				<ChevronLeft size={16} />
-			</button>
-
-			<div class="flex items-center gap-1 font-mono text-xs text-ink-600 dark:text-ink-400">
-				<span>{currentPage}</span>
-				<span class="text-ink-300 dark:text-ink-700">/</span>
-				<span>{totalPages}</span>
-			</div>
-
-			<button
-				class="p-2 rounded-lg text-ink-500 hover:bg-ink-100 dark:text-ink-400 dark:hover:bg-ink-800 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-				disabled={currentPage === totalPages}
-				onclick={() => handlePageChange(currentPage + 1)}
-				aria-label="下一页"
-			>
-				<ChevronRight size={16} />
-			</button>
-		</div>
-	{/if}
-
 	{#if showFediverseSection}
-		<!-- Fediverse Section (Collapsible) -->
-		<div class="mb-20 mt-12">
+		<div class="mb-14 -mt-6">
 			<details class="group">
 				<summary
 					class="flex items-center gap-2 text-xs text-ink-800/50 dark:text-ink-200/50 hover:text-jade-600 dark:hover:text-jade-400 transition-colors font-serif tracking-wider cursor-pointer list-none outline-none"
@@ -206,12 +193,10 @@
 						class="i-lucide-chevron-down w-3 h-3 text-ink-400 group-open:rotate-180 transition-transform"
 					></div>
 				</summary>
-
 				<div
 					class="mt-4 p-5 bg-ink-50 dark:bg-[#252525] border border-ink-200 dark:border-ink-200/50 rounded-default animate-in slide-in-from-top-2 duration-300"
 				>
 					<div class="space-y-3">
-						<!-- AP Object URL (copyable) -->
 						<div>
 							<label
 								for="fediverse-object-url"
@@ -237,11 +222,10 @@
 								</button>
 							</div>
 							<div class="text-[10px] text-ink-400 dark:text-ink-500 mt-1">
-								复制此地址，在你的实例中搜索即可找到这篇文章。
+								复制此地址，在你的实例中搜索即可找到这篇内容。
 							</div>
 						</div>
 
-						<!-- Instance domain input + jump button -->
 						<div>
 							<label
 								for="fediverse-instance-domain"
@@ -269,6 +253,36 @@
 					</div>
 				</div>
 			</details>
+		</div>
+	{/if}
+
+	<CommentList />
+
+	{#if totalPages > 1}
+		<div class="flex items-center justify-center gap-2 mt-8 mb-12">
+			<button
+				class="p-2 rounded-lg text-ink-500 hover:bg-ink-100 dark:text-ink-400 dark:hover:bg-ink-800 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+				disabled={currentPage === 1}
+				onclick={() => handlePageChange(currentPage - 1)}
+				aria-label="上一页"
+			>
+				<ChevronLeft size={16} />
+			</button>
+
+			<div class="flex items-center gap-1 font-mono text-xs text-ink-600 dark:text-ink-400">
+				<span>{currentPage}</span>
+				<span class="text-ink-300 dark:text-ink-700">/</span>
+				<span>{totalPages}</span>
+			</div>
+
+			<button
+				class="p-2 rounded-lg text-ink-500 hover:bg-ink-100 dark:text-ink-400 dark:hover:bg-ink-800 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+				disabled={currentPage === totalPages}
+				onclick={() => handlePageChange(currentPage + 1)}
+				aria-label="下一页"
+			>
+				<ChevronRight size={16} />
+			</button>
 		</div>
 	{/if}
 </div>


### PR DESCRIPTION
### Motivation
- Extract avatar URLs from remote actors so federated commenters can have avatars shown locally. 
- Unify and extend comment target resolution to support articles, moments and thinkings (by object ID or local URLs) when creating comments from ActivityPub objects. 
- Prevent creating admin replies to federated comments to avoid accidental interactions with remote actors and persist user Fediverse instance preference in the comment UI.

### Description
- Added `remoteMediaRef` and expanded `remoteActor` with `Icon` and `Image`, plus an `avatarURL()` helper to pick an avatar URL. 
- Introduced `commentTarget` and refactored `resolveCommentTarget` and `resolveContentByLocalURL` to return `commentTarget` and to resolve `/posts/`, `/moments/`, `/thinkings` and `/ap/objects/*` paths and ActivityPub object IDs, returning the corresponding comment `AreaID` when available. 
- Updated `handleCreateAsComment` to use the new target type, set the comment `Avatar` from the remote actor, and use `AreaID` from the `commentTarget`. 
- Disallowed replying to federated comments in `ReplyComment` by returning `ErrCommentReplyDisabled` when the parent comment has `IsFederated == true`. 
- Frontend `CommentAreaClient.svelte` changes to persist the Fediverse instance domain to `localStorage` under the key `comment:fediverse-instance-domain`, load it on init, move the fediverse section before the comment list/pagination, and small copy/text and layout adjustments.

### Testing
- Ran server unit tests with `go test ./...`, which completed successfully. 
- Built the frontend with `npm run build` to validate Svelte changes, which succeeded. 
- No additional automated regressions were reported by basic build/test runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a93d90ebc4832a93429eefba0aa172)