### PR TITLE
Add center alignment options for Hero component

### DIFF
--- a/admin/src/views/settings/unified/components/tabs/ThemeExtendTab.vue
+++ b/admin/src/views/settings/unified/components/tabs/ThemeExtendTab.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
-import { NAlert, NButton, NTag, useMessage } from 'naive-ui'
+import { NAlert, NButton, NForm, NFormItem, NSelect, NTag, useMessage } from 'naive-ui'
 import { computed, onMounted, ref, watch } from 'vue'
 
 import TemplateEditor from '@/components/template-editor/TemplateEditor.vue'
 import { listWebsiteInfo, updateWebsiteInfo } from '@/services/website-info'
+
+import type { SelectOption } from 'naive-ui'
 
 const emit = defineEmits<{ 'dirty-change': [dirty: boolean] }>()
 
@@ -14,6 +16,15 @@ const saving = ref(false)
 const jsonText = ref('')
 const originalJson = ref('')
 const jsonError = ref<string | null>(null)
+const mottoLinesAlign = ref<'default' | 'center'>('default')
+const socialsAlign = ref<'default' | 'center'>('default')
+const syncFromJson = ref(false)
+const syncFromForm = ref(false)
+
+const alignOptions: SelectOption[] = [
+  { label: '默认', value: 'default' },
+  { label: '居中', value: 'center' },
+]
 
 const jsonValid = computed(() => !jsonError.value)
 const isDirty = computed(() => jsonText.value.trim() !== originalJson.value.trim())
@@ -26,17 +37,80 @@ watch(
     const source = value.trim()
     if (!source) {
       jsonError.value = null
+      syncFromJson.value = true
+      mottoLinesAlign.value = 'default'
+      socialsAlign.value = 'default'
+      syncFromJson.value = false
       return
     }
     try {
-      JSON.parse(source)
+      const parsed = JSON.parse(source)
       jsonError.value = null
+      if (!syncFromForm.value) {
+        const heroAlign = readHeroAlignFromThemeExtendInfo(parsed)
+        syncFromJson.value = true
+        mottoLinesAlign.value = heroAlign.mottoLinesAlign
+        socialsAlign.value = heroAlign.socialsAlign
+        syncFromJson.value = false
+      }
     } catch (err) {
       jsonError.value = err instanceof Error ? err.message : 'JSON 格式不正确'
     }
   },
   { immediate: true },
 )
+
+watch([mottoLinesAlign, socialsAlign], ([nextMottoAlign, nextSocialAlign]) => {
+  if (syncFromJson.value || !jsonValid.value) return
+
+  try {
+    syncFromForm.value = true
+    jsonText.value = JSON.stringify(
+      mergeHeroAlignIntoThemeExtendInfo(jsonText.value, nextMottoAlign, nextSocialAlign),
+      null,
+      2,
+    )
+  } finally {
+    syncFromForm.value = false
+  }
+})
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function normalizeAlign(value: unknown): 'default' | 'center' {
+  return value === 'center' ? 'center' : 'default'
+}
+
+function readHeroAlignFromThemeExtendInfo(value: unknown) {
+  const root = isRecord(value) ? value : {}
+  const home = isRecord(root.home) ? root.home : root
+  const hero = isRecord(home.hero) ? home.hero : {}
+
+  return {
+    mottoLinesAlign: normalizeAlign(hero.mottoLinesAlign),
+    socialsAlign: normalizeAlign(hero.socialsAlign),
+  }
+}
+
+function mergeHeroAlignIntoThemeExtendInfo(
+  source: string,
+  nextMottoAlign: 'default' | 'center',
+  nextSocialAlign: 'default' | 'center',
+) {
+  const parsed = JSON.parse(source.trim() || '{}')
+  const root = isRecord(parsed) ? { ...parsed } : {}
+  const home = isRecord(root.home) ? { ...root.home } : {}
+  const hero = isRecord(home.hero) ? { ...home.hero } : {}
+
+  hero.mottoLinesAlign = nextMottoAlign
+  hero.socialsAlign = nextSocialAlign
+  home.hero = hero
+  root.home = home
+
+  return root
+}
 
 async function fetchData() {
   loading.value = true
@@ -124,6 +198,31 @@ onMounted(fetchData)
       </div>
     </div>
 
+    <div class="shrink-0 rounded-lg border border-neutral-200 bg-white px-4 py-3 dark:border-neutral-700 dark:bg-neutral-900">
+      <NForm
+        label-placement="left"
+        label-width="auto"
+        class="flex flex-wrap items-center justify-start gap-x-4 gap-y-3"
+      >
+        <NFormItem label="mottoLines排版" class="mb-0 theme-align-form-item">
+          <NSelect
+            v-model:value="mottoLinesAlign"
+            :options="alignOptions"
+            :disabled="loading || saving || !jsonValid"
+            class="theme-align-select"
+          />
+        </NFormItem>
+        <NFormItem label="socials排版" class="mb-0 theme-align-form-item">
+          <NSelect
+            v-model:value="socialsAlign"
+            :options="alignOptions"
+            :disabled="loading || saving || !jsonValid"
+            class="theme-align-select"
+          />
+        </NFormItem>
+      </NForm>
+    </div>
+
     <!-- Editor fills remaining space -->
     <TemplateEditor v-model="jsonText" class="theme-editor min-h-0 flex-1" />
 
@@ -138,5 +237,25 @@ onMounted(fetchData)
 .theme-editor :deep(.cm-editor) {
   height: 100%;
   min-height: unset;
+}
+
+.theme-align-form-item :deep(.n-form-item-blank) {
+  align-items: center;
+  justify-content: flex-start;
+}
+
+.theme-align-form-item {
+  display: inline-flex;
+  align-items: center;
+  margin-right: 0;
+}
+
+.theme-align-form-item :deep(.n-form-item-feedback-wrapper) {
+  display: flex;
+  align-items: center;
+}
+
+.theme-align-select {
+  width: 140px;
 }
 </style>

--- a/web/src/lib/features/home/Hero.svelte
+++ b/web/src/lib/features/home/Hero.svelte
@@ -45,9 +45,11 @@
 	const mottoLines = $derived(
 		config?.mottoLines && config.mottoLines.length > 0 ? config.mottoLines : defaultMottoLines
 	);
+	const mottoLinesAlign = $derived(config?.mottoLinesAlign ?? 'default');
 	const socials = $derived(
 		config?.socials && config.socials.length > 0 ? config.socials : defaultSocials
 	);
+	const socialsAlign = $derived(config?.socialsAlign ?? 'default');
 
 	function resolveNodeClass(node: HomeHeroTemplateNode): string {
 		const baseClass = node.type === 'h1' ? 'text-ink-900 dark:text-ink-100' : '';
@@ -102,18 +104,24 @@
 
 		<div class="flex flex-col gap-12 ml-4">
 			<FadeIn y={16} duration={900} delay={400}>
-				<div class="hero-motto text-center font-serif text-2xl leading-relaxed text-ink-800 dark:text-ink-200">
+				<div
+					class="hero-motto font-serif text-2xl leading-relaxed text-ink-800 dark:text-ink-200"
+					class:text-center={mottoLinesAlign === 'center'}
+				>
 					{#each mottoLines as line, lineIdx (`${line}-${lineIdx}`)}
 						{line}<br />
 					{/each}
 				</div>
 			</FadeIn>
 
-			<FadeIn y={12} duration={800} delay={600}>
-				<div class="social-container flex items-center justify-center gap-6">
-					{#each socials as social, socialIdx (`${social.icon}-${social.href}-${socialIdx}`)}
-						<SocialItem icon={social.icon} name={social.name} href={social.href} />
-					{/each}
+				<FadeIn y={12} duration={800} delay={600}>
+					<div
+						class="social-container flex items-center gap-6"
+						class:justify-center={socialsAlign === 'center'}
+					>
+						{#each socials as social, socialIdx (`${social.icon}-${social.href}-${socialIdx}`)}
+							<SocialItem icon={social.icon} name={social.name} href={social.href} />
+						{/each}
 				</div>
 			</FadeIn>
 		</div>

--- a/web/src/lib/features/home/Hero.svelte
+++ b/web/src/lib/features/home/Hero.svelte
@@ -102,7 +102,7 @@
 
 		<div class="flex flex-col gap-12 ml-4">
 			<FadeIn y={16} duration={900} delay={400}>
-				<div class="hero-motto font-serif text-2xl leading-relaxed text-ink-800 dark:text-ink-200">
+				<div class="hero-motto text-center font-serif text-2xl leading-relaxed text-ink-800 dark:text-ink-200">
 					{#each mottoLines as line, lineIdx (`${line}-${lineIdx}`)}
 						{line}<br />
 					{/each}

--- a/web/src/lib/features/home/Hero.svelte
+++ b/web/src/lib/features/home/Hero.svelte
@@ -110,7 +110,7 @@
 			</FadeIn>
 
 			<FadeIn y={12} duration={800} delay={600}>
-				<div class="social-container flex items-center gap-6">
+				<div class="social-container flex items-center justify-center gap-6">
 					{#each socials as social, socialIdx (`${social.icon}-${social.href}-${socialIdx}`)}
 						<SocialItem icon={social.icon} name={social.name} href={social.href} />
 					{/each}

--- a/web/src/lib/features/home/theme.ts
+++ b/web/src/lib/features/home/theme.ts
@@ -1,6 +1,7 @@
 import type { WebsiteInfoMap } from '$lib/features/website-info/types';
 import type {
 	HomeActivityPulseThemeConfig,
+	HomeHeroAlignMode,
 	HomeHeroSocialLink,
 	HomeHeroTemplateNode,
 	HomeInspirationIconName,
@@ -12,6 +13,7 @@ import type {
 } from './types';
 
 const allowedHeroTemplateTypes = new Set(['h1', 'span', 'code', 'br']);
+const allowedHeroAlignModes = new Set(['default', 'center']);
 const allowedInspirationIconNames = new Set([
 	'quote',
 	'code2',
@@ -51,7 +53,9 @@ const defaultThemeConfig: HomeThemeConfig = {
 			'热衷于在逻辑与感性的缝隙中构建数字花园。',
 			'也许，代码是现代的诗歌，而文字是思想的快照。'
 		],
-		socials: defaultHeroSocials
+		mottoLinesAlign: 'default',
+		socials: defaultHeroSocials,
+		socialsAlign: 'default'
 	},
 	activityPulse: {
 		title: '创作律动',
@@ -131,6 +135,14 @@ const toStringValue = (value: unknown): string | undefined => {
 	}
 	const trimmed = value.trim();
 	return trimmed.length > 0 ? trimmed : undefined;
+};
+
+const parseHeroAlignMode = (value: unknown): HomeHeroAlignMode | undefined => {
+	const align = toStringValue(value);
+	if (!align || !allowedHeroAlignModes.has(align)) {
+		return undefined;
+	}
+	return align as HomeHeroAlignMode;
 };
 
 const toPositiveInt = (value: unknown): number | undefined => {
@@ -364,7 +376,11 @@ export const resolveHomeThemeConfig = (
 			parseHeroTemplate(isRecord(heroRaw.title) ? heroRaw.title.template : heroRaw.titleTemplate) ??
 			defaultThemeConfig.hero?.titleTemplate,
 		mottoLines: parseStringList(heroRaw.mottoLines) ?? defaultThemeConfig.hero?.mottoLines,
-		socials: parseSocials(heroRaw.socials) ?? defaultThemeConfig.hero?.socials
+		mottoLinesAlign:
+			parseHeroAlignMode(heroRaw.mottoLinesAlign) ?? defaultThemeConfig.hero?.mottoLinesAlign,
+		socials: parseSocials(heroRaw.socials) ?? defaultThemeConfig.hero?.socials,
+		socialsAlign:
+			parseHeroAlignMode(heroRaw.socialsAlign) ?? defaultThemeConfig.hero?.socialsAlign
 	};
 
 	const activity = {

--- a/web/src/lib/features/home/types.ts
+++ b/web/src/lib/features/home/types.ts
@@ -37,12 +37,16 @@ export type HomeHeroSocialLink = {
 	href: string;
 };
 
+export type HomeHeroAlignMode = 'default' | 'center';
+
 export type HomeHeroThemeConfig = {
 	avatarUrl?: string;
 	description?: string;
 	titleTemplate?: HomeHeroTemplateNode[];
 	mottoLines?: string[];
+	mottoLinesAlign?: HomeHeroAlignMode;
 	socials?: HomeHeroSocialLink[];
+	socialsAlign?: HomeHeroAlignMode;
 };
 
 export type HomeActivityPulseThemeConfig = {


### PR DESCRIPTION
This pull request introduces new alignment options for the home page hero section, allowing admins to control the alignment of motto lines and social links via the settings UI. The changes ensure that these alignment preferences are saved, parsed, and applied consistently across the admin interface and frontend rendering.

**Admin UI enhancements:**

* Added `NSelect` dropdowns for `mottoLinesAlign` and `socialsAlign` in `ThemeExtendTab.vue`, enabling selection between 'default' and 'center' alignment. The selections are synchronized with the JSON editor and persisted in the theme config. [[1]](diffhunk://#diff-ce11d73c2e0bbd60c6a4ebdef384533f98338058d49c3931fbb26b65f2345f4eL2-R9) [[2]](diffhunk://#diff-ce11d73c2e0bbd60c6a4ebdef384533f98338058d49c3931fbb26b65f2345f4eR19-R27) [[3]](diffhunk://#diff-ce11d73c2e0bbd60c6a4ebdef384533f98338058d49c3931fbb26b65f2345f4eR40-R114) [[4]](diffhunk://#diff-ce11d73c2e0bbd60c6a4ebdef384533f98338058d49c3931fbb26b65f2345f4eR201-R225)

* Introduced styling for the new alignment controls to ensure a consistent and user-friendly interface.

**Frontend rendering updates:**

* Updated `Hero.svelte` to apply text alignment to motto lines and horizontal alignment to social links based on the new `mottoLinesAlign` and `socialsAlign` config values. [[1]](diffhunk://#diff-8584a4fd95dc4c893264343488166d8aea086aaa4906cfcd0312d963824c2318R48-R52) [[2]](diffhunk://#diff-8584a4fd95dc4c893264343488166d8aea086aaa4906cfcd0312d963824c2318L105-R121)

**Theme config and parsing logic:**

* Extended `HomeHeroThemeConfig` type and default config to include `mottoLinesAlign` and `socialsAlign`, and added parsing logic to support these new fields. [[1]](diffhunk://#diff-2b4b2c4548407a1007493d2a939e5e69624480e87ca535ad6a9cd7f36d1851d2R4) [[2]](diffhunk://#diff-2b4b2c4548407a1007493d2a939e5e69624480e87ca535ad6a9cd7f36d1851d2R16) [[3]](diffhunk://#diff-2b4b2c4548407a1007493d2a939e5e69624480e87ca535ad6a9cd7f36d1851d2L54-R58) [[4]](diffhunk://#diff-2b4b2c4548407a1007493d2a939e5e69624480e87ca535ad6a9cd7f36d1851d2R140-R147) [[5]](diffhunk://#diff-2b4b2c4548407a1007493d2a939e5e69624480e87ca535ad6a9cd7f36d1851d2L367-R383) [[6]](diffhunk://#diff-35b551d310ae87c83847d4ef76040bb347f2efa69f83b3a1713be3f8b84fad20R40-R49)

<img width="1913" height="1080" alt="图片" src="https://github.com/user-attachments/assets/77c5460a-062e-4d4d-87c6-b0b7d4106d67" />
<img width="1357" height="614" alt="图片" src="https://github.com/user-attachments/assets/93057dbe-0df0-4d2f-9949-ea25e51848f3" />
